### PR TITLE
Add `@internal` to list of ignored tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ type TypeParameterData = {
 
 Parses the exported functions defined in the given `globs` of TypeScript files.
 
-- Functions with the `@ignore` JSDoc tag will be skipped.
+- Functions with the `@ignore` or `@internal` JSDoc tag(s) will be skipped.
 - Functions will be sorted in *ascending* order of their `@weight` JSDoc tag. A function with the `@weight` tag will be ranked *before* a function without the `@weight` tag.
 
 ***Parameters***

--- a/src/utilities/utilities/utilities/parse-js-doc.ts
+++ b/src/utilities/utilities/utilities/parse-js-doc.ts
@@ -25,7 +25,7 @@ export function parseJsDoc(node: ts.Node): null | {
   }
   const tags = parseTags(jsDocCommentNode)
   if (tags !== null && (typeof tags.ignore !== 'undefined' || typeof tags.internal !== 'undefined')) {
-    // Has `@ignore` tag, so return `null`
+    // Has `@ignore` or `@internal` tag, so return `null`
     return null
   }
   const description = (jsDocCommentNode as ts.JSDoc).comment

--- a/src/utilities/utilities/utilities/parse-js-doc.ts
+++ b/src/utilities/utilities/utilities/parse-js-doc.ts
@@ -24,7 +24,7 @@ export function parseJsDoc(node: ts.Node): null | {
     }
   }
   const tags = parseTags(jsDocCommentNode)
-  if (tags !== null && typeof tags.ignore !== 'undefined') {
+  if (tags !== null && (typeof tags.ignore !== 'undefined' || typeof tags.internal !== 'undefined')) {
     // Has `@ignore` tag, so return `null`
     return null
   }

--- a/src/utilities/utilities/utilities/parse-js-doc.ts
+++ b/src/utilities/utilities/utilities/parse-js-doc.ts
@@ -24,7 +24,10 @@ export function parseJsDoc(node: ts.Node): null | {
     }
   }
   const tags = parseTags(jsDocCommentNode)
-  if (tags !== null && (typeof tags.ignore !== 'undefined' || typeof tags.internal !== 'undefined')) {
+  if (
+    tags !== null &&
+    (typeof tags.ignore !== 'undefined' || typeof tags.internal !== 'undefined')
+  ) {
     // Has `@ignore` or `@internal` tag, so return `null`
     return null
   }

--- a/src/utilities/utilities/utilities/parse-js-doc.ts
+++ b/src/utilities/utilities/utilities/parse-js-doc.ts
@@ -4,7 +4,7 @@ import { JsDocTagsData } from '../../../types.js'
 import { findFirstChildNodeOfKind } from './operations/find-first-child-node-of-kind.js'
 import { traverseNode } from './traverse-node.js'
 
-// Returns `null` if the JSDoc comment contains an `@ignore` tag
+// Returns `null` if the JSDoc comment contains an `@ignore` or `@internal` tag
 export function parseJsDoc(node: ts.Node): null | {
   description: null | string
   parameters: null | JsDocTagsData

--- a/test/fixtures/8-ignore-tag/code.ts
+++ b/test/fixtures/8-ignore-tag/code.ts
@@ -5,6 +5,13 @@ export function add(x: number, y: number): number {
   return x + y
 }
 
+/**
+ * @internal
+ */
+export function subtract(x: number, y: number): number {
+  return x - y
+}
+
 export function noop(): void {
   return
 }


### PR DESCRIPTION
`@internal` is often used to declare a TSDoc/JSDoc comment to be stripped from public documentation, so this should be supported as part of this package.

See https://tsdoc.org/pages/tags/internal/