### PR TITLE
Exclude simple-git-hooks from release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 lib/
 node_modules/
 *.log
+*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generate-ts-docs",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generate-ts-docs",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19,6 +19,7 @@
         "@types/node": "^20.2.4",
         "@typescript-eslint/eslint-plugin": "5.59.7",
         "ava": "^5.3.0",
+        "clean-package": "^2.2.0",
         "eslint": "^8.41.0",
         "eslint-config-yuanqing": "0.0.8",
         "eslint-plugin-import": "2.27.5",
@@ -1422,6 +1423,18 @@
       "integrity": "sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==",
       "dev": true
     },
+    "node_modules/clean-package": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-package/-/clean-package-2.2.0.tgz",
+      "integrity": "sha512-vLv8kRqvh4smPDpqAYFPLEijTppAd/cfCz4yBcUGoVl/JKu6ZWKhlo+G/cAmwlSa29RudfBeuyiNEzas8bTwEQ==",
+      "dev": true,
+      "dependencies": {
+        "dot-prop": "^6.0.1"
+      },
+      "bin": {
+        "clean-package": "bin/main.js"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
@@ -1754,6 +1767,21 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eastasianwidth": {
@@ -3317,6 +3345,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-path-inside": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "prepublishOnly": "npm run build",
     "reset": "npm run clean && rimraf node_modules package-lock.json && npm install",
     "test": "ava 'test/**/*.ts'",
-    "watch": "npm run clean && tsc --watch"
+    "watch": "npm run clean && tsc --watch",
+    "prepack": "clean-package",
+    "postpack": "clean-package restore"
   },
   "dependencies": {
     "github-slugger": "^2.0.0",
@@ -49,6 +51,7 @@
     "@types/node": "^20.2.4",
     "@typescript-eslint/eslint-plugin": "5.59.7",
     "ava": "^5.3.0",
+    "clean-package": "^2.2.0",
     "eslint": "^8.41.0",
     "eslint-config-yuanqing": "0.0.8",
     "eslint-plugin-import": "2.27.5",
@@ -93,5 +96,13 @@
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged",
     "pre-push": "npm run lint && npm run fix && npm run build && npm run test"
+  },
+  "clean-package": {
+    "indent": 2,
+    "backupPath": "./node_modules/clean-package/package.json.backup",
+    "remove": [
+      "scripts.postinstall",
+      "simple-git-hooks"
+    ]
   }
 }


### PR DESCRIPTION
Hey, I wanted to try out your package to generate some juicy documentation, but when trying to install it, I get this error:


> npm ERR! Der Befehl "simple-git-hooks" ist entweder falsch geschrieben oder
> npm ERR! konnte nicht gefunden werden.

Which means something alike
> The command "simple-git-hooks" either has a typo or does not exist

When looking into your code, my guess was that npm executes your `postinstall` script when installing your package into a project.

By using `clean-package`, you can temporarily alter your `package.json` while packing and releasing. Excluding `simple-git-hooks` from the release should then solve the above error. :)

You should be able to reproduce this error by:
1. `$ mkdir my-project`
2. `$ cd my-project`
3. `$ npm init`
4. spam enter
5. `$ npm i -D generate-ts-docs`

You can test my changes within your project by running:
1. `$ npm pack`
2. check the `package.json` within the created `generate-ts-docs-0.0.14.tgz`

Hopefully this helps :)